### PR TITLE
onPagesInitialized event now loads plugin options

### DIFF
--- a/tntsearch.php
+++ b/tntsearch.php
@@ -132,7 +132,7 @@ class TNTSearchPlugin extends Plugin
         /** @var Uri $uri */
         $uri = $this->grav['uri'];
 
-        $options = [];
+        $options = $this->config->get('plugins.tntsearch');
 
         $this->current_route = $uri->path();
 


### PR DESCRIPTION
Using version 1.2.5, fuzzy search isn't working when enabled in the plugin config. In my case, the search form simply submits the query to `/search?q=search+keywords` and renders the results via a custom template.

The problem seems to be that there's no mechanism for loading the plugin options in the above scenario. In `TNTSearchPlugin::onPagesInitialized`, the `GravTNTSearch` instance is initialized with an empty array of options, resulting in `GravTNTSearch::__construct` setting default option values.

As a workaround, I've modified `TNTSearchPlugin::onPagesInitialized` to initialize the plugin options from the plugin configuration (`$options = $this->config->get('plugins.tntsearch');`).  I'm sure that loads some unused keys into the options array, but achieves the results I'm looking for (i.e. fuzzy search is now configurable via the plugin options).